### PR TITLE
change name in package.json to not conflict with the real backbone

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name"          : "backbone",
+  "name"          : "backbone-lite",
   "description"   : "Give your JS App some Backbone with Models, Views, Collections, and Events.",
   "url"           : "http://backbonejs.org",
   "keywords"      : ["model", "view", "controller", "router", "server", "client", "browser"],


### PR DESCRIPTION
Give backbone lite a unique package name so that `jest-haste-map` doesn't get confused.  Without jest outputs the following error:
```
jest-haste-map: Haste module naming collision: backbone
  The following files share their name; please adjust your hasteImpl:
    * <rootDir>/third_party/javascript-khansrc/backbone-src/package.json
    * <rootDir>/third_party/javascript-khansrc/backbone-lite-src/package.json

 FAIL  javascript/sat-mission-package/fixtures_test.js
  ● Test suite failed to run

    The name `backbone` was looked up in the Haste module map. It cannot be resolved, because there exists several different files, or packages, that provide a module for that particular name and platform. The platform is generic (no extension). You must delete or blacklist files until there remains only one of these:

      * `/Users/kevinbarabash/khan/webapp/third_party/javascript-khansrc/backbone-lite-src/package.json` (package)
      * `/Users/kevinbarabash/khan/webapp/third_party/javascript-khansrc/backbone-src/package.json` (package)

      3 | /* To fix, remove an entry above, run ka-lint, and fix errors. */
      4 | var $ = require("jquery");
    > 5 | var Backbone = require("backbone");
        |                ^
...
```

This is needed for https://phabricator.khanacademy.org/D53481.